### PR TITLE
Set Ubuntu's conf_dir variable to /etc/roundcube

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -36,6 +36,7 @@ roundcubemail_requirements: "{{ _roundcubemail_requirements[ansible_distribution
 _roundcubemail_conf_dir:
   default: /etc/roundcubemail
   Archlinux: /etc/webapps/roundcubemail/config
+  Ubuntu: /etc/roundcube
 
 roundcubemail_conf_dir: "{{ _roundcubemail_conf_dir[ansible_distribution] | default(_roundcubemail_conf_dir['default']) }}"
 

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -36,6 +36,7 @@ roundcubemail_requirements: "{{ _roundcubemail_requirements[ansible_distribution
 _roundcubemail_conf_dir:
   default: /etc/roundcubemail
   Archlinux: /etc/webapps/roundcubemail/config
+  Debian: /etc/roundcube
   Ubuntu: /etc/roundcube
 
 roundcubemail_conf_dir: "{{ _roundcubemail_conf_dir[ansible_distribution] | default(_roundcubemail_conf_dir['default']) }}"


### PR DESCRIPTION
**Describe the change**
The default value for roundcube's config directory is `/etc/roundcubemail`, but on Ubuntu 16.04 (haven't looked at other versions) the `roundcube-core` package uses `/etc/roundcube`. This sets the correct value for `_roundcubemail_conf_dir` for Ubuntu platforms to `/etc/roundcube`.

**Testing**
I tested this change by applying the role to an Ubuntu system and then verifying that `/etc/roundcube/config.inc.php` matched `templates/config.inc.php.j2` instead of the `roundcube-core` package's default file.
