### PR TITLE
enh: Add roundcube plugins activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,15 @@ roundcubemail_smtp_server: localhost
 roundcubemail_smtp_port: 25
 roundcubemail_smtp_user: ""
 roundcubemail_smtp_pass: ""
+
+roundcubemail_plugins: []
+```
+
+You can add plugin by setting roundcubemail_plugins array:
+```yaml
+roundcubemail_plugins:
+  - managesieve
+  - password
 ```
 
 ## [Requirements](#requirements)

--- a/README.md
+++ b/README.md
@@ -98,11 +98,14 @@ roundcubemail_smtp_port: 25
 roundcubemail_smtp_user: ""
 roundcubemail_smtp_pass: ""
 
+roundcubemail_extra_packages: []
 roundcubemail_plugins: []
 ```
 
 You can add plugin by setting roundcubemail_plugins array:
 ```yaml
+roundcubemail_extra_packages:
+  - roundcube-plugins
 roundcubemail_plugins:
   - managesieve
   - password

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,3 +24,5 @@ roundcubemail_smtp_server: localhost
 roundcubemail_smtp_port: 25
 roundcubemail_smtp_user: ""
 roundcubemail_smtp_pass: ""
+
+roundcubemail_plugins: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,4 +25,5 @@ roundcubemail_smtp_port: 25
 roundcubemail_smtp_user: ""
 roundcubemail_smtp_pass: ""
 
+roundcubemail_extra_packages: []
 roundcubemail_plugins: []

--- a/templates/config.inc.php.j2
+++ b/templates/config.inc.php.j2
@@ -45,7 +45,7 @@ $config['des_key'] = '{{ roundcubemail_des_key }}';
 // PLUGINS
 // ----------------------------------
 // List of active plugins (in plugins/ directory)
-$config['plugins'] = array();
+$config['plugins'] = array({{ roundcubemail_plugins_array }});
 
 // Set the spell checking engine. Possible values:
 // - 'googie'  - the default (also used for connecting to Nox Spell Server, see 'spellcheck_uri' setting)

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -51,6 +51,8 @@ _roundcubemail_packages:
 
 roundcubemail_packages: "{{ _roundcubemail_packages[ansible_os_family] | default(_roundcubemail_packages['default']) }}"
 
+roundcubemail_plugins_array: "{% if roundcubemail_plugins | length > 0 %}'{{ roundcubemail_plugins | join(\"', '\")}}'{% endif %}"
+
 _roundcubemail_conf_dir:
   default: /etc/roundcubemail
   Debian: /etc/roundcube

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -49,7 +49,7 @@ _roundcubemail_packages:
   Debian:
     - roundcube
 
-roundcubemail_packages: "{{ _roundcubemail_packages[ansible_os_family] | default(_roundcubemail_packages['default']) }}"
+roundcubemail_packages: "{{ ( _roundcubemail_packages[ansible_os_family] | default(_roundcubemail_packages['default']) ) + roundcubemail_extra_packages }}"
 
 roundcubemail_plugins_array: "{% if roundcubemail_plugins | length > 0 %}'{{ roundcubemail_plugins | join(\"', '\")}}'{% endif %}"
 


### PR DESCRIPTION
---
name: Pull request
about: Add roundcube plugins activation

---

**Describe the change**
Allow to install `roundcube-plugins` package and activate  roundcube plugins via a new list variable:
```
roundcubemail_extra_packages:
  - roundcube-plugins

roundcubemail_plugins:
  - plugin1
  - plugin2
```
**Testing**
Install extra package:
```
TASK [ansible-role-roundcube : Install roundcubemail] ********************
Suggested packages:
  php-crypt-gpg php-zip
The following NEW packages will be installed:
  roundcube-plugins
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
changed: [srv.domain.tld]
```

Deployed with 5 plugins on servers:
```
TASK [ansible-role-roundcube : Configure roundcubemail] ********************
--- before: /etc/roundcube/config.inc.php
+++ after: ...../config.inc.php.j2
@@ -45,7 +45,7 @@
 // PLUGINS
 // ----------------------------------
 // List of active plugins (in plugins/ directory)
-$config['plugins'] = array();
+$config['plugins'] = array('managesieve', 'markasjunk', 'password', 'zipdownload', 'archive');
 
 // Set the spell checking engine. Possible values:
 // - 'googie'  - the default (also used for connecting to Nox Spell Server, see 'spellcheck_uri' setting)

changed: [srv.domain.tld]
```
With an empty list:
```
TASK [ansible-role-roundcube : Configure roundcubemail] ********************
--- before: /etc/roundcube/config.inc.php
+++ after: ...../config.inc.php.j2
@@ -45,7 +45,7 @@
 // PLUGINS
 // ----------------------------------
 // List of active plugins (in plugins/ directory)
-$config['plugins'] = array('managesieve', 'markasjunk', 'password', 'zipdownload', 'archive');
+$config['plugins'] = array();
 
 // Set the spell checking engine. Possible values:
 // - 'googie'  - the default (also used for connecting to Nox Spell Server, see 'spellcheck_uri' setting)

changed: [srv.domain.tld]
```